### PR TITLE
refactor: Default to cuid() for id field

### DIFF
--- a/lib/fields.ts
+++ b/lib/fields.ts
@@ -15,7 +15,7 @@ export const FIELDS = [
 export const ID_FIELD: Field = {
   relationField: false,
   documentation: "",
-  default: "uuid()",
+  default: "cuid()",
   required: true,
   type: "String",
   unique: true,

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -10,6 +10,11 @@ export const PRISMA_DEFAULT_VALUE_FNS = [
     description: "Automatically generate a random UUID",
   },
   {
+    value: "cuid()",
+    label: "A random CUID",
+    description: "Automatically generate a random CUID",
+  },
+  {
     value: "now()",
     label: "Current date",
     description: "The current date once the row is inserted",


### PR DESCRIPTION
<img width="1110" alt="image" src="https://user-images.githubusercontent.com/19674362/143678991-2feee7d2-561f-4374-82da-03a825776b06.png">

## Changes

- Switch to defaulting ID fields with `cuid()` instead of `uuid()`
- Add `cuid()` to possible default values combo box