### PR TITLE
feat: Add database provider selector

### DIFF
--- a/components/AddField.tsx
+++ b/components/AddField.tsx
@@ -92,7 +92,10 @@ const AddField = ({
           label="Type"
           key={type}
         >
-          {[...TYPES(schema.database), ...schema.models].map((type) => (
+          {[
+            ...TYPES(schema.database),
+            ...schema.models.map((m) => ({ ...m, description: "" })),
+          ].map((type) => (
             <Select.Option description={type.description} key={type.name}>
               {type.name}
             </Select.Option>

--- a/components/AddField.tsx
+++ b/components/AddField.tsx
@@ -1,8 +1,8 @@
 import Modal from "./Modal";
 import { Button, Select, TextField } from "@prisma/lens";
-import { FIELDS } from "../lib/fields";
+import { TYPES } from "../lib/fields";
 import { Field, Model } from "../lib/types";
-import { PRISMA_DEFAULT_VALUE_FNS } from "../lib/prisma";
+import { PRISMA_DEFAULT_VALUES } from "../lib/prisma";
 import { useEffect, useState } from "react";
 import { useSchemaContext } from "../lib/context";
 
@@ -92,9 +92,9 @@ const AddField = ({
           label="Type"
           key={type}
         >
-          {[...FIELDS, ...schema.models].map((field) => (
-            <Select.Option description={field.description} key={field.name}>
-              {field.name}
+          {[...TYPES(schema.database), ...schema.models].map((type) => (
+            <Select.Option description={type.description} key={type.name}>
+              {type.name}
             </Select.Option>
           ))}
         </Select.Container>
@@ -106,7 +106,7 @@ const AddField = ({
           hint="A Prisma default value function"
           label="Default value"
         >
-          {PRISMA_DEFAULT_VALUE_FNS.map((field) => (
+          {PRISMA_DEFAULT_VALUES.map((field) => (
             <Select.Option description={field.description} key={field.value}>
               {field.label}
             </Select.Option>

--- a/components/Models.tsx
+++ b/components/Models.tsx
@@ -3,13 +3,22 @@ import Link from "next/link";
 import Modal from "./Modal";
 import Schema from "./Schema";
 import toast from "react-hot-toast";
-import { Button, Separator, Card, Title, TextField, Menu } from "@prisma/lens";
+import {
+  Button,
+  Separator,
+  Card,
+  Title,
+  TextField,
+  Menu,
+  Select,
+} from "@prisma/lens";
 import { ID_FIELD } from "../lib/fields";
 import { Globe, Box, X, Edit, CheckSquare, MoreVertical } from "react-feather";
 import { Model, Schema as SchemaType } from "../lib/types";
 import { useRouter } from "next/dist/client/router";
 import { useSchemaContext } from "../lib/context";
 import { useEffect, useState } from "react";
+import { PRISMA_DATABASES } from "../lib/prisma";
 
 export default function Models() {
   const { schema, schemas, setSchema, setSchemas } = useSchemaContext();
@@ -132,6 +141,24 @@ export default function Models() {
               </Menu.Body>
             </Menu.Container>
           </div>
+
+          <Select.Container
+            selectedKey={schema.database}
+            onSelectionChange={(key) => {
+              setSchema({
+                ...schema,
+                database: key,
+              });
+            }}
+            placeholder="Select a provider"
+            label="Provider"
+          >
+            {PRISMA_DATABASES.map((db) => (
+              <Select.Option key={db.value}>{db.label}</Select.Option>
+            ))}
+          </Select.Container>
+
+          <Separator />
 
           {schema.models.map((model: Model, i: number) => {
             return (

--- a/components/Models.tsx
+++ b/components/Models.tsx
@@ -93,7 +93,7 @@ export default function Models() {
               <button
                 onClick={() => {
                   if (editingName && name !== schema.name) {
-                    if (schemas.some((m: Model) => m.name === name)) {
+                    if (schemas.some((s) => s.name === name)) {
                       toast.error(`A schema called ${name} exists`);
                       setName(schema.name);
                     } else {

--- a/components/SchemaGraph.tsx
+++ b/components/SchemaGraph.tsx
@@ -84,7 +84,7 @@ const SchemaGraph = () => {
                     ];
                   }
                 )
-                .reduce((a: Field[], b: Field) => a.concat(b)),
+                .reduce((a, b) => a.concat(b)),
             ]
           : []
       }

--- a/components/Schemas.tsx
+++ b/components/Schemas.tsx
@@ -2,12 +2,12 @@ import Link from "next/link";
 import toast from "react-hot-toast";
 import { Button, Separator, Card } from "@prisma/lens";
 import { Layers } from "react-feather";
-import { Model, Schema } from "../lib/types";
+import { Schema } from "../lib/types";
 import { useRouter } from "next/dist/client/router";
 import { useSchemaContext } from "../lib/context";
 
 export default function Schemas() {
-  const { schema, schemas, setSchemas } = useSchemaContext();
+  const { schemas, setSchemas } = useSchemaContext();
   const router = useRouter();
 
   return (
@@ -36,7 +36,8 @@ export default function Schemas() {
               ) {
                 toast.error("A schema called New schema exists");
               } else {
-                const newSchema = {
+                const newSchema: Schema = {
+                  database: "postgresql",
                   name: "New schema",
                   models: [],
                   enums: [],

--- a/components/UpdateField.tsx
+++ b/components/UpdateField.tsx
@@ -1,8 +1,8 @@
 import Modal from "./Modal";
 import { Button, Select, Separator, TextField } from "@prisma/lens";
-import { FIELDS } from "../lib/fields";
+import { TYPES } from "../lib/fields";
 import { Field, Model } from "../lib/types";
-import { PRISMA_DEFAULT_VALUE_FNS } from "../lib/prisma";
+import { PRISMA_DEFAULT_VALUES } from "../lib/prisma";
 import { useEffect, useState } from "react";
 import { useSchemaContext } from "../lib/context";
 
@@ -93,9 +93,9 @@ const UpdateField = ({
           label="Type"
           key={type}
         >
-          {[...FIELDS, ...schema.models].map((field) => (
-            <Select.Option description={field.description} key={field.name}>
-              {field.name}
+          {[...TYPES(schema.database), ...schema.models].map((type) => (
+            <Select.Option description={type.description} key={type.name}>
+              {type.name}
             </Select.Option>
           ))}
         </Select.Container>
@@ -108,7 +108,7 @@ const UpdateField = ({
           label="Default value"
           key={defaultValue}
         >
-          {PRISMA_DEFAULT_VALUE_FNS.map((field) => (
+          {PRISMA_DEFAULT_VALUES.map((field) => (
             <Select.Option description={field.description} key={field.value}>
               {field.label}
             </Select.Option>

--- a/components/UpdateField.tsx
+++ b/components/UpdateField.tsx
@@ -93,7 +93,10 @@ const UpdateField = ({
           label="Type"
           key={type}
         >
-          {[...TYPES(schema.database), ...schema.models].map((type) => (
+          {[
+            ...TYPES(schema.database),
+            ...schema.models.map((m) => ({ ...m, description: "" })),
+          ].map((type) => (
             <Select.Option description={type.description} key={type.name}>
               {type.name}
             </Select.Option>

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -1,12 +1,13 @@
 import { createContext, useContext } from "react";
+import { Schema } from "./types";
 
 export const SchemaContext = createContext<{
-  schema: any;
-  schemas: any[];
+  schema: Schema;
+  schemas: Schema[];
   setSchema: (schema: any) => void;
   setSchemas: (schemas: any[]) => void;
 }>({
-  schema: {},
+  schema: {} as Schema,
   schemas: [],
   setSchema: () => undefined,
   setSchemas: () => undefined,

--- a/lib/fields.ts
+++ b/lib/fields.ts
@@ -1,16 +1,27 @@
-import { Field } from "./types";
+import { Field, PrismaDatabase } from "./types";
 
-export const FIELDS = [
-  { name: "DateTime", description: "A calendar date" },
-  { name: "String", description: "Any text" },
-  { name: "Boolean", description: "True or False" },
-  { name: "Int", description: "A fixed number" },
-  { name: "BigInt", description: "A very big number" },
-  { name: "Float", description: "Float number" },
-  { name: "Decimal", description: "Decimal number" },
-  { name: "Json", description: "Any JSON data" },
-  { name: "Bytes", description: "Abstract bytes data" },
-];
+export const TYPES = (database: PrismaDatabase) => {
+  const ALL_TYPES = [
+    { name: "DateTime", description: "A calendar date" },
+    { name: "String", description: "Any text" },
+    { name: "Boolean", description: "True or False" },
+    { name: "Int", description: "A fixed number" },
+    { name: "BigInt", description: "A very big number" },
+    { name: "Float", description: "Float number" },
+    { name: "Decimal", description: "Decimal number" },
+    { name: "Json", description: "Any JSON data" },
+    { name: "Bytes", description: "Abstract bytes data" },
+  ];
+
+  switch (database) {
+    case "sqlite":
+      return ALL_TYPES.filter(
+        (type) => type.name !== "Json" && type.name !== "Bytes"
+      );
+    default:
+      return ALL_TYPES;
+  }
+};
 
 export const ID_FIELD: Field = {
   relationField: false,

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,4 +1,6 @@
-export const PRISMA_DEFAULT_VALUE_FNS = [
+import { PrismaDatabase } from "./types";
+
+export const PRISMA_DEFAULT_VALUES = [
   {
     value: "autoincrement()",
     label: "Automatic incrementation",
@@ -29,4 +31,10 @@ export const PRISMA_DEFAULT_VALUE_FNS = [
     label: "True",
     description: "",
   },
+];
+
+export const PRISMA_DATABASES: { label: string; value: PrismaDatabase }[] = [
+  { label: "PostgreSQL", value: "postgresql" },
+  { label: "SQLite", value: "sqlite" },
+  { label: "MySQL", value: "mysql" },
 ];

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -17,6 +17,10 @@ export type Model = {
 };
 
 export type Schema = {
-  name: string;
+  database: PrismaDatabase;
   models: Model[];
+  enums: any[];
+  name: string;
 };
+
+export type PrismaDatabase = "postgresql" | "sqlite" | "mysql";

--- a/pages/schemas/[schemaId]/models/[id]/index.tsx
+++ b/pages/schemas/[schemaId]/models/[id]/index.tsx
@@ -17,7 +17,7 @@ const Model = () => {
   const { query, asPath, push } = useRouter();
   const { id } = query;
 
-  const model = schema.models?.[id as string];
+  const model = schema.models?.[Number(id)];
 
   const [editingField, setEditingField] = useState<string>();
   const [addingField, setAddingField] = useState<string>();
@@ -71,7 +71,7 @@ const Model = () => {
         model={model}
         defaultValues={
           model?.fields?.find((field: Field) => field.name === editingField) ??
-          {}
+          ({} as Field)
         }
         open={Boolean(editingField)}
         onSubmit={(field) => {
@@ -226,7 +226,10 @@ const Model = () => {
                 <h2 className="font-semibold text-xl">Add field</h2>
 
                 <div className="flex flex-col space-y-3">
-                  {[...TYPES(schema.database), ...schema.models].map((type) => {
+                  {[
+                    ...TYPES(schema.database),
+                    ...schema.models.map((m) => ({ ...m, description: "" })),
+                  ].map((type) => {
                     const Icon = type.name
                       ? prismaTypesToIcons[type.name] ??
                         prismaTypesToIcons.Relation

--- a/pages/schemas/[schemaId]/models/[id]/index.tsx
+++ b/pages/schemas/[schemaId]/models/[id]/index.tsx
@@ -5,7 +5,7 @@ import UpdateField from "../../../../../components/UpdateField";
 import toast from "react-hot-toast";
 import { Button, Menu, Separator, TextField, Title } from "@prisma/lens";
 import { CheckSquare, Edit, MoreVertical, Trash2 } from "react-feather";
-import { FIELDS } from "../../../../../lib/fields";
+import { TYPES } from "../../../../../lib/fields";
 import { prismaTypesToIcons } from "../../../../../lib/icons";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/dist/client/router";
@@ -226,26 +226,26 @@ const Model = () => {
                 <h2 className="font-semibold text-xl">Add field</h2>
 
                 <div className="flex flex-col space-y-3">
-                  {[...FIELDS, ...schema.models].map((field) => {
-                    const Icon = field.name
-                      ? prismaTypesToIcons[field.name] ??
+                  {[...TYPES(schema.database), ...schema.models].map((type) => {
+                    const Icon = type.name
+                      ? prismaTypesToIcons[type.name] ??
                         prismaTypesToIcons.Relation
                       : prismaTypesToIcons.default;
 
                     return (
                       <button
                         className="rounded-lg bg-white shadow-md text-left border border-transparent hover:border-blue-500 cursor-pointer transition py-3 px-4 flex items-center space-x-4"
-                        onClick={() => setAddingField(field.name)}
-                        key={field.name}
+                        onClick={() => setAddingField(type.name)}
+                        key={type.name}
                       >
                         <div className="rounded-md bg-blue-100 flex items-center justify-center p-3">
                           <Icon className="text-blue-600" size={20} />
                         </div>
 
                         <div className="flex flex-col">
-                          <h3 className="font-medium">{field.name}</h3>
+                          <h3 className="font-medium">{type.name}</h3>
                           <p className="text-sm text-gray-700">
-                            {field.description}
+                            {type.description}
                           </p>
                         </div>
                       </button>


### PR DESCRIPTION
Closes #13 

## Changes

- Introduces a dropdown for selecting which database provider you'll be using for your Prisma setup. When changing this, the app now makes sure to only show the database types which are supported by that provider!

![CleanShot 2021-12-04 at 11 35 27@2x](https://user-images.githubusercontent.com/19674362/144706434-01085134-3452-493a-86ea-f6ae548aeceb.png)

![CleanShot 2021-12-04 at 11 24 17](https://user-images.githubusercontent.com/19674362/144706099-0df1f5b0-5157-4162-b0c3-3897ebe40020.gif)
