### PR TITLE
fix: Use enums from imported schema

### DIFF
--- a/components/ImportSchema.tsx
+++ b/components/ImportSchema.tsx
@@ -1,7 +1,7 @@
 import axios from "axios";
 import toast from "react-hot-toast";
 import { Button } from "@prisma/lens";
-import { Model } from "../lib/types";
+import { Enum, Model } from "../lib/types";
 import { apiUrl } from "../lib/config";
 import { useSchemaContext } from "../lib/context";
 import { useState } from "react";
@@ -46,10 +46,20 @@ const ImportSchema = ({ onClose }: ImportSchemaProps) => {
               ) {
                 toast.error("Some model has a colliding name");
                 setImportSchemaLoading(false);
+              } else if (
+                schema.enums.some((enumValue: Enum) =>
+                  importedSchema.enums
+                    .map((e: Enum) => e.name)
+                    .includes(enumValue.name)
+                )
+              ) {
+                toast.error("Some enum has a colliding name");
+                setImportSchemaLoading(false);
               } else if (importedSchema.models?.length) {
                 setSchema({
                   ...schema,
                   models: [...schema.models, ...importedSchema.models],
+                  enums: [...schema.enums, ...(importedSchema.enums ?? [])],
                 });
                 setImportSchemaLoading(false);
                 setImportSchema("");

--- a/components/Models.tsx
+++ b/components/Models.tsx
@@ -203,7 +203,7 @@ export default function Models() {
 
           <Label>Enums</Label>
 
-          {schema.enums.map((e, i) => {
+          {schema.enums.map((e) => {
             return (
               <button
                 className="flex border border-transparent focus:border-blue-500 hover:border-blue-500 transition rounded-lg cursor-pointer"


### PR DESCRIPTION
Closes #33 

When you imported a schema before this, the enums you specified in the
schema wouldn't actually follow. This fixes that.