### PR TITLE
Fix:Provider Dropdown menu color scheme fixed while in DarkMode

### DIFF
--- a/components/Models.tsx
+++ b/components/Models.tsx
@@ -306,7 +306,7 @@ export default function Models() {
         <div className="p-5">
           <Link
             href="/"
-            className="text-gray-600 dark:text-neutral-500 font-medium text-sm flex items-center gap-2 hover:underline underline-offset-4"
+            className="flex items-center gap-2 text-sm font-medium text-gray-600 dark:text-neutral-500 hover:underline underline-offset-4"
           >
             <ArrowLeftIcon className="w-4" />
             <span>Back</span>
@@ -373,7 +373,7 @@ export default function Models() {
             }}
           >
             {PRISMA_DATABASES.map((PRISMA_DATABASE) => (
-              <option key={PRISMA_DATABASE.value} value={PRISMA_DATABASE.value}>
+              <option key={PRISMA_DATABASE.value} value={PRISMA_DATABASE.value} className="dark:bg-gray-600">
                 {PRISMA_DATABASE.label}
               </option>
             ))}


### PR DESCRIPTION
Previously the Dark Mode Dropdown :

![Before](https://github.com/albingroen/prismabuilder.io/assets/45139653/91f30fdd-24b9-4d5a-85b7-a00ce13e8ce1)

After Fixing:

![Screenshot 2023-11-15 004357](https://github.com/albingroen/prismabuilder.io/assets/45139653/2124f842-6f41-40ca-8394-08bed83ebf82)

Code Changes: Changed tailwind style for Option Tag