### PR TITLE
Fix Select List Text Visibility in Dark Mode

### DIFF
--- a/components/Models.tsx
+++ b/components/Models.tsx
@@ -373,11 +373,7 @@ export default function Models() {
             }}
           >
             {PRISMA_DATABASES.map((PRISMA_DATABASE) => (
-              <option
-                key={PRISMA_DATABASE.value}
-                value={PRISMA_DATABASE.value}
-                className="dark:bg-gray-600"
-              >
+              <option key={PRISMA_DATABASE.value} value={PRISMA_DATABASE.value}>
                 {PRISMA_DATABASE.label}
               </option>
             ))}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -6,6 +6,10 @@
   body {
     @apply antialiased bg-gray-100 dark:bg-neutral-800 text-black dark:text-white;
   }
+
+  select option {
+    @apply dark:bg-gray-600;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
### Description

**Fixes Issue #71** where select list text was invisible in dark mode. The text was white on a white background. This issue is common across multiple sites, but not reproducible in Safari (Mac OS) as they have their own custom select boxes. The fix applies to Chrome, Edge and Firefox browsers.

The code change updated the select list text in dark mode to match the look of the "Provider Select" located on the left side of the app.

### Screenshots (Before & After)

<img src="https://github.com/user-attachments/assets/30f7052c-8187-4549-95b7-7baab3c34560" width="150" height="150">
<img src="https://github.com/user-attachments/assets/7cc732ab-e12c-411e-8408-4acd67641e7b" width="150" height="150">

