### PR TITLE
feat: edit model name from sidebar

### DIFF
--- a/components/EditableItem.tsx
+++ b/components/EditableItem.tsx
@@ -1,0 +1,81 @@
+import { PencilSquareIcon } from "@heroicons/react/24/outline";
+import { useRouter } from "next/dist/client/router";
+import { useState } from "react";
+import { useSchemaContext } from "../lib/context";
+import { Model } from "../lib/types";
+
+const EditableItem = ({
+  name,
+  schemaName,
+}: {
+  name: string;
+  schemaName: string;
+}) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [updatedName, setUpdatedName] = useState(name ?? "");
+  const { push } = useRouter();
+  const { schema, setSchema } = useSchemaContext();
+
+  const handleChangeName = (newName: string) => {
+    if (newName.trim() === name.trim()) {
+      setIsEditing(false);
+      return;
+    }
+    if (newName && newName !== name) {
+      setSchema({
+        ...schema,
+        models: schema.models.map((m: Model) =>
+          m.name === name
+            ? {
+                ...m,
+                name: newName,
+              }
+            : m,
+        ),
+      });
+      push(`/schemas/${schemaName}/models/${newName}`);
+      setIsEditing(false);
+    }
+  };
+  return (
+    <div className="w-full max-w-sm">
+      {isEditing ? (
+        <input
+          type="text"
+          value={updatedName}
+          onChange={(e) => setUpdatedName(e.target.value)}
+          onBlur={() => {
+            if (updatedName.trim() === "") {
+              setUpdatedName(name);
+              setIsEditing(false);
+              return;
+            }
+            handleChangeName(updatedName);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              handleChangeName(updatedName);
+            }
+          }}
+          autoFocus
+          className="w-full bg-transparent h-0 focus:outline-none focus:ring-0 border-none"
+        />
+      ) : (
+        <div className="flex items-center justify-between">
+          <p className="truncate">{updatedName}</p>
+          <div
+            role="button"
+            aria-label="Edit name"
+            onClick={() => setIsEditing(true)}
+            className="cursor-pointer"
+          >
+            <PencilSquareIcon className="w-4 text-gray-500 dark:text-neutral-500 hover:text-inherit dark:hover:text-inherit transition" />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default EditableItem;

--- a/components/Models.tsx
+++ b/components/Models.tsx
@@ -47,6 +47,7 @@ import {
   DropResult,
 } from "react-beautiful-dnd";
 import { copyToClipboard } from "../lib/utils";
+import EditableItem from "./EditableItem";
 
 export default function Models() {
   const { schema, schemas, setSchema, setSchemas } = useSchemaContext();
@@ -425,7 +426,10 @@ export default function Models() {
                                     isDragging={isDragging}
                                     isActive={isActive}
                                   >
-                                    {model.name}
+                                    <EditableItem
+                                      name={model.name}
+                                      schemaName={schema.name}
+                                    />
                                   </SidebarItem>
                                 </div>
                               )}


### PR DESCRIPTION
Before this commit, we were not able to edit model name from sidebar, we can only do this by clicking on h2 in page.

After this commit, we can edit model name from from sidebar too.


[Demo Video](https://drive.google.com/file/d/1iOVLymXmJ0qyONX5SOAlJXpRKASnRBNG/view?usp=sharing)